### PR TITLE
Implement role-based auth flow

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,10 @@
 import Link from 'next/link';
-import { isAuthenticated, clearToken } from '../utils/auth';
+import {
+  isAuthenticated,
+  clearToken,
+  getRole,
+  getDashboardRoute,
+} from '../utils/auth';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -10,15 +15,23 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             Feed
           </Link>
           {isAuthenticated() ? (
-            <button
-              onClick={() => {
-                clearToken();
-                window.location.href = '/login';
-              }}
-              className="hover:underline"
-            >
-              Logout
-            </button>
+            <>
+              <Link
+                href={getDashboardRoute(getRole())}
+                className="hover:underline"
+              >
+                Dashboard
+              </Link>
+              <button
+                onClick={() => {
+                  clearToken();
+                  window.location.href = '/login';
+                }}
+                className="hover:underline"
+              >
+                Logout
+              </button>
+            </>
           ) : (
             <>
               <Link href="/login" className="hover:underline">

--- a/frontend/src/components/withAuth.tsx
+++ b/frontend/src/components/withAuth.tsx
@@ -1,0 +1,27 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState, ComponentType } from 'react';
+import { getToken, getRole, getDashboardRoute } from '../utils/auth';
+
+export default function withAuth<P>(Wrapped: ComponentType<P>, roles: string[]) {
+  return function Protected(props: P) {
+    const router = useRouter();
+    const [allowed, setAllowed] = useState(false);
+
+    useEffect(() => {
+      const token = getToken();
+      const role = getRole();
+      if (!token) {
+        router.replace('/login');
+        return;
+      }
+      if (role && !roles.includes(role)) {
+        router.replace(getDashboardRoute(role));
+        return;
+      }
+      setAllowed(true);
+    }, []);
+
+    if (!allowed) return null;
+    return <Wrapped {...props} />;
+  };
+}

--- a/frontend/src/pages/admin/painel.tsx
+++ b/frontend/src/pages/admin/painel.tsx
@@ -1,0 +1,7 @@
+import withAuth from '../../components/withAuth';
+
+function AdminPainel() {
+  return <h1>Painel Admin</h1>;
+}
+
+export default withAuth(AdminPainel, ['admin']);

--- a/frontend/src/pages/empresa/dashboard.tsx
+++ b/frontend/src/pages/empresa/dashboard.tsx
@@ -1,0 +1,7 @@
+import withAuth from '../../components/withAuth';
+
+function EmpresaDashboard() {
+  return <h1>Dashboard da Empresa</h1>;
+}
+
+export default withAuth(EmpresaDashboard, ['empresa']);

--- a/frontend/src/pages/investidor/dashboard.tsx
+++ b/frontend/src/pages/investidor/dashboard.tsx
@@ -1,0 +1,7 @@
+import withAuth from '../../components/withAuth';
+
+function InvestidorDashboard() {
+  return <h1>Dashboard do Investidor</h1>;
+}
+
+export default withAuth(InvestidorDashboard, ['investidor']);

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import api from '../services/api';
-import { setToken } from '../utils/auth';
+import { setToken, setRole, parseToken, getDashboardRoute } from '../utils/auth';
 
 export default function Login() {
   const router = useRouter();
@@ -13,8 +13,15 @@ export default function Login() {
     e.preventDefault();
     try {
       const res = await api.post('/auth/login', { email, password });
-      setToken(res.data.token);
-      router.push('/feed');
+      const token = res.data.token;
+      setToken(token);
+      const payload = parseToken(token);
+      if (payload?.role) {
+        setRole(payload.role);
+        router.push(getDashboardRoute(payload.role));
+      } else {
+        router.push('/');
+      }
     } catch (err) {
       setError('Credenciais inválidas');
     }

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,9 +1,21 @@
 const TOKEN_KEY = 'scalex_token';
+const ROLE_KEY = 'scalex_role';
 
 export function setToken(token: string) {
   if (typeof window !== 'undefined') {
     localStorage.setItem(TOKEN_KEY, token);
   }
+}
+
+export function setRole(role: string) {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(ROLE_KEY, role);
+  }
+}
+
+export function getRole(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(ROLE_KEY);
 }
 
 export function getToken(): string | null {
@@ -14,9 +26,31 @@ export function getToken(): string | null {
 export function clearToken() {
   if (typeof window !== 'undefined') {
     localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(ROLE_KEY);
   }
 }
 
 export function isAuthenticated() {
   return !!getToken();
+}
+
+export function parseToken(token: string): any | null {
+  try {
+    const payload = token.split('.')[1];
+    const decoded = atob(payload);
+    return JSON.parse(decoded);
+  } catch (e) {
+    return null;
+  }
+}
+
+export function getDashboardRoute(role: string | null) {
+  switch (role) {
+    case 'empresa':
+      return '/empresa/dashboard';
+    case 'admin':
+      return '/admin/painel';
+    default:
+      return '/investidor/dashboard';
+  }
 }


### PR DESCRIPTION
## Summary
- store role alongside token and handle redirection utilities
- create `withAuth` HOC to protect private pages
- add dashboards for empresa, investidor and admin
- redirect after login according to role
- expose dashboard link in layout when logged in

## Testing
- `npm test` *(fails: jest not found)*
- `npm run cypress run` *(fails: cypress not found)*