### PR TITLE
Add admin panel with analytics and management tables

### DIFF
--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -7,3 +7,54 @@ export async function dashboard(_req: Request, res: Response) {
   const proposals = await prisma.proposal.count();
   return res.json({ users, projects, proposals });
 }
+
+export async function analytics(_req: Request, res: Response) {
+  const totalCompanies = await prisma.user.count({ where: { role: 'empresa' } });
+  const totalInvestors = await prisma.user.count({ where: { role: 'investidor' } });
+  const totalPosts = await prisma.post.count();
+
+  const proposalsPending = await prisma.proposal.count({ where: { status: 'pendente' } });
+  const proposalsAccepted = await prisma.proposal.count({ where: { status: 'aceita' } });
+  const proposalsRejected = await prisma.proposal.count({ where: { status: 'recusada' } });
+
+  const totalInvestedAgg = await prisma.proposal.aggregate({
+    where: { status: 'aceita' },
+    _sum: { amount: true },
+  });
+  const totalInvested = totalInvestedAgg._sum.amount || 0;
+  const totalCommission = totalInvested * 0.05;
+
+  return res.json({
+    totalCompanies,
+    totalInvestors,
+    totalPosts,
+    proposals: {
+      pending: proposalsPending,
+      accepted: proposalsAccepted,
+      rejected: proposalsRejected,
+    },
+    negotiations: proposalsAccepted,
+    totalInvested,
+    totalCommission,
+  });
+}
+
+export async function listAllProposals(_req: Request, res: Response) {
+  const proposals = await prisma.proposal.findMany({
+    include: { investor: true, project: true },
+  });
+  return res.json(proposals);
+}
+
+export async function listNegotiations(_req: Request, res: Response) {
+  const negotiations = await prisma.proposal.findMany({
+    where: { status: 'aceita' },
+    include: { investor: true, project: true },
+  });
+  return res.json(negotiations);
+}
+
+export async function listPosts(_req: Request, res: Response) {
+  const posts = await prisma.post.findMany({ include: { author: true } });
+  return res.json(posts);
+}

--- a/backend/src/middleware/adminOnly.ts
+++ b/backend/src/middleware/adminOnly.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+export function adminOnly(req: Request, res: Response, next: NextFunction) {
+  const auth = req.headers.authorization;
+  if (auth && auth.startsWith('Bearer ')) {
+    const token = auth.substring(7);
+    try {
+      const payload = jwt.verify(token, JWT_SECRET) as any;
+      if (payload.role !== 'admin') {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+      return next();
+    } catch {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+  }
+  return res.status(401).json({ error: 'Unauthorized' });
+}

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -1,12 +1,24 @@
 import { Router } from 'express';
-import { dashboard } from '../controllers/adminController';
+import {
+  dashboard,
+  analytics,
+  listAllProposals,
+  listNegotiations,
+  listPosts,
+} from '../controllers/adminController';
 import { authMiddleware } from '../middleware/auth';
+import { adminOnly } from '../middleware/adminOnly';
 import prisma from '../prisma/client';
 
 const router = Router();
 
 router.use(authMiddleware);
+router.use(adminOnly);
 router.get('/dashboard', dashboard);
+router.get('/analytics', analytics);
+router.get('/proposals', listAllProposals);
+router.get('/negotiations', listNegotiations);
+router.get('/posts', listPosts);
 router.get('/users', async (_req, res) => {
   const users = await prisma.user.findMany();
   res.json(users);

--- a/frontend/src/components/AnalyticsCard.tsx
+++ b/frontend/src/components/AnalyticsCard.tsx
@@ -1,0 +1,8 @@
+export default function AnalyticsCard({ title, value }: { title: string; value: React.ReactNode }) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <p className="text-sm text-gray-500">{title}</p>
+      <p className="text-xl font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/NegotiationTable.tsx
+++ b/frontend/src/components/NegotiationTable.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+export interface Negotiation {
+  id: number;
+  amount: number;
+  status: string;
+  investor?: { name?: string } | null;
+  project?: { title?: string } | null;
+}
+
+export default function NegotiationTable({ negotiations }: { negotiations: Negotiation[] }) {
+  const [filter, setFilter] = useState('');
+  const filtered = negotiations.filter((n) => {
+    const term = filter.toLowerCase();
+    return (
+      n.project?.title?.toLowerCase().includes(term) ||
+      n.investor?.name?.toLowerCase().includes(term)
+    );
+  });
+
+  return (
+    <div className="mb-8">
+      <h2 className="text-lg font-semibold mb-2">Negociações</h2>
+      <input
+        placeholder="Filtrar"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        className="border p-2 mb-2"
+      />
+      <div className="overflow-x-auto">
+        <table className="min-w-full border text-sm">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="border px-2 py-1">Projeto</th>
+              <th className="border px-2 py-1">Investidor</th>
+              <th className="border px-2 py-1">Valor</th>
+              <th className="border px-2 py-1">Status</th>
+              <th className="border px-2 py-1">Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((n) => (
+              <tr key={n.id} className="text-center">
+                <td className="border px-2 py-1">{n.project?.title || n.id}</td>
+                <td className="border px-2 py-1">{n.investor?.name || n.id}</td>
+                <td className="border px-2 py-1">{n.amount}</td>
+                <td className="border px-2 py-1">
+                  <span className="px-2 py-1 rounded bg-gray-200">{n.status}</span>
+                </td>
+                <td className="border px-2 py-1">
+                  <button disabled className="text-xs bg-gray-300 px-2 py-1 cursor-not-allowed">Cancelar negociação</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProposalTable.tsx
+++ b/frontend/src/components/ProposalTable.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+
+export interface Proposal {
+  id: number;
+  amount: number;
+  status: string;
+  investor?: { name?: string } | null;
+  project?: { title?: string } | null;
+}
+
+export default function ProposalTable({ proposals }: { proposals: Proposal[] }) {
+  const [filter, setFilter] = useState('');
+  const filtered = proposals.filter((p) => {
+    const term = filter.toLowerCase();
+    return (
+      p.status.toLowerCase().includes(term) ||
+      p.project?.title?.toLowerCase().includes(term) ||
+      p.investor?.name?.toLowerCase().includes(term)
+    );
+  });
+
+  return (
+    <div className="mb-8">
+      <h2 className="text-lg font-semibold mb-2">Propostas</h2>
+      <input
+        placeholder="Filtrar"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        className="border p-2 mb-2"
+      />
+      <div className="overflow-x-auto">
+        <table className="min-w-full border text-sm">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="border px-2 py-1">Projeto</th>
+              <th className="border px-2 py-1">Investidor</th>
+              <th className="border px-2 py-1">Valor</th>
+              <th className="border px-2 py-1">Status</th>
+              <th className="border px-2 py-1">Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((p) => (
+              <tr key={p.id} className="text-center">
+                <td className="border px-2 py-1">{p.project?.title || p.id}</td>
+                <td className="border px-2 py-1">{p.investor?.name || p.id}</td>
+                <td className="border px-2 py-1">{p.amount}</td>
+                <td className="border px-2 py-1">
+                  <span className="px-2 py-1 rounded bg-gray-200">{p.status}</span>
+                </td>
+                <td className="border px-2 py-1">
+                  <button disabled className="text-xs bg-gray-300 px-2 py-1 mr-1 cursor-not-allowed">Cancelar</button>
+                  <button disabled className="text-xs bg-gray-300 px-2 py-1 cursor-not-allowed">Suspender usuário</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/painel.tsx
+++ b/frontend/src/pages/admin/painel.tsx
@@ -1,7 +1,95 @@
+import { useEffect, useState } from 'react';
 import withAuth from '../../components/withAuth';
+import api from '../../services/api';
+import AnalyticsCard from '../../components/AnalyticsCard';
+import ProposalTable, { Proposal } from '../../components/ProposalTable';
+import NegotiationTable, { Negotiation } from '../../components/NegotiationTable';
+
+interface Analytics {
+  totalCompanies: number;
+  totalInvestors: number;
+  totalPosts: number;
+  proposals: { pending: number; accepted: number; rejected: number };
+  negotiations: number;
+  totalInvested: number;
+  totalCommission: number;
+}
+
+interface Post {
+  id: number;
+  title: string;
+  author?: { name?: string } | null;
+}
 
 function AdminPainel() {
-  return <h1>Painel Admin</h1>;
+  const [analytics, setAnalytics] = useState<Analytics | null>(null);
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [negotiations, setNegotiations] = useState<Negotiation[]>([]);
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [postFilter, setPostFilter] = useState('');
+
+  useEffect(() => {
+    api.get('/admin/analytics').then((res) => setAnalytics(res.data)).catch(() => setAnalytics(null));
+    api.get('/admin/proposals').then((res) => setProposals(res.data)).catch(() => setProposals([]));
+    api.get('/admin/negotiations').then((res) => setNegotiations(res.data)).catch(() => setNegotiations([]));
+    api.get('/admin/posts').then((res) => setPosts(res.data)).catch(() => setPosts([]));
+  }, []);
+
+  if (!analytics) return <p>Carregando...</p>;
+
+  const filteredPosts = posts.filter((p) =>
+    p.title.toLowerCase().includes(postFilter.toLowerCase())
+  );
+
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-4">Painel Admin</h1>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <AnalyticsCard title="Empresas" value={analytics.totalCompanies} />
+        <AnalyticsCard title="Investidores" value={analytics.totalInvestors} />
+        <AnalyticsCard title="Postagens" value={analytics.totalPosts} />
+        <AnalyticsCard title="Propostas pendentes" value={analytics.proposals.pending} />
+        <AnalyticsCard title="Propostas aceitas" value={analytics.proposals.accepted} />
+        <AnalyticsCard title="Propostas recusadas" value={analytics.proposals.rejected} />
+        <AnalyticsCard title="Negociações" value={analytics.negotiations} />
+        <AnalyticsCard title="Total investido" value={`$${analytics.totalInvested}`} />
+        <AnalyticsCard title="Comissões" value={`$${analytics.totalCommission}`} />
+      </div>
+      <ProposalTable proposals={proposals} />
+      <NegotiationTable negotiations={negotiations} />
+      <div className="mb-8">
+        <h2 className="text-lg font-semibold mb-2">Postagens</h2>
+        <input
+          placeholder="Filtrar"
+          value={postFilter}
+          onChange={(e) => setPostFilter(e.target.value)}
+          className="border p-2 mb-2"
+        />
+        <div className="overflow-x-auto">
+          <table className="min-w-full border text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="border px-2 py-1">Título</th>
+                <th className="border px-2 py-1">Autor</th>
+                <th className="border px-2 py-1">Ações</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredPosts.map((post) => (
+                <tr key={post.id} className="text-center">
+                  <td className="border px-2 py-1">{post.title}</td>
+                  <td className="border px-2 py-1">{post.author?.name || post.id}</td>
+                  <td className="border px-2 py-1">
+                    <button disabled className="text-xs bg-gray-300 px-2 py-1 cursor-not-allowed">Destacar postagem</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default withAuth(AdminPainel, ['admin']);


### PR DESCRIPTION
## Summary
- secure `/admin` routes with adminOnly middleware
- expose analytics, proposals, negotiations and posts for admin
- implement admin panel page using new components
- create `AnalyticsCard`, `ProposalTable` and `NegotiationTable`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run cypress` *(fails: cypress not found)*