### PR TITLE
Fix JSON parsing and log user registration

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -6,6 +6,7 @@ import prisma from '../prisma/client';
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
 export async function register(req: Request, res: Response) {
+  console.log('RAW BODY:', req.body);
   const { name, email, password, role } = req.body as {
     name?: string;
     email?: string;
@@ -23,7 +24,7 @@ export async function register(req: Request, res: Response) {
         name,
         email,
         passwordHash: hash,
-        role: (role as any) || 'investidor',
+        role: (role?.toUpperCase() as any) || 'INVESTIDOR',
       },
     });
     return res.status(201).json({ id: user.id, email: user.email });

--- a/docs/test_register.sh
+++ b/docs/test_register.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Example curl command to test registration endpoint
+curl -X POST http://localhost:4000/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Test","email":"test@example.com","password":"123456","role":"INVESTIDOR"}'


### PR DESCRIPTION
## Notes
- Added console log to debug the raw body on registration
- Forced role value to upper case to match Prisma enum
- Created `docs/test_register.sh` with example curl for local testing

## Testing
- `npm test --prefix backend` *(fails: jest not found)*