### PR TITLE
Fix register schema mismatch

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,7 +11,7 @@ model User {
   id            Int            @id @default(autoincrement())
   name          String
   email         String         @unique
-  password      String
+  passwordHash String
   role          Role
   createdAt     DateTime       @default(now())
   posts         Post[]         @relation("UserPosts")


### PR DESCRIPTION
## Summary
- rename the `password` field in the Prisma schema to `passwordHash`

## Testing
- `npx prisma validate` *(fails: connect EHOSTUNREACH)*
- `npm test` *(fails: jest: not found)*
- `curl -i -X POST https://scalex-invest.onrender.com/auth/register` *(fails: couldn't connect to server)*