### PR TITLE
Fix Express middleware typing

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import authRoutes from './routes/authRoutes';
 import proposalRoutes from './routes/proposalRoutes';
@@ -17,7 +17,7 @@ app.use(cors({
 }));
 
 // log every incoming request for debugging
-app.use((req, _res, next) => {
+app.use((req: Request, _res: Response, next: NextFunction) => {
   console.log(req.method, req.path);
   next();
 });


### PR DESCRIPTION
## Summary
- import `NextFunction` in server entry point
- type logging middleware and call `next()`

## Testing
- `npm test` *(fails: jest not found)*