### PR TITLE
fix(frontend): usar URL da API de producao com NEXT_PUBLIC_API_URL

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://scalex-invest.onrender.com

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -4,7 +4,7 @@ export default function Home() {
   const [status, setStatus] = useState<'loading' | 'ok' | 'error'>('loading');
 
   useEffect(() => {
-    fetch('http://localhost:4000/health')
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/health`)
       .then((res) => res.json())
       .then((data) => {
         setStatus(data.status === 'ok' ? 'ok' : 'error');

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { getToken } from '../utils/auth';
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000',
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
 });
 
 api.interceptors.request.use((config) => {

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -7,7 +7,7 @@
     }
   ],
   "env": {
-    "NEXT_PUBLIC_API_URL": "https://scalex-invest-api.onrender.com"
+    "NEXT_PUBLIC_API_URL": "https://scalex-invest.onrender.com"
   },
   "routes": [
     {


### PR DESCRIPTION
## Summary
- configure frontend to use NEXT_PUBLIC_API_URL
- fetch health check with env variable
- add `.env.local` file with production API URL
- set same URL in vercel.json

## Testing
- `npm test` (failed: jest not found)
- `npm test` in frontend (failed: missing script)
