### PR TITLE
fix(frontend): corrigir verificação do status da API para ambiente de produção

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -4,8 +4,14 @@ export default function Home() {
   const [status, setStatus] = useState<'loading' | 'ok' | 'error'>('loading');
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/health`)
-      .then((res) => res.json())
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (!apiUrl) {
+      setStatus('error');
+      return;
+    }
+
+    fetch(`${apiUrl}/health`)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data) => {
         setStatus(data.status === 'ok' ? 'ok' : 'error');
       })


### PR DESCRIPTION
## Notes
- Ajusta a verificação do status da API na página inicial utilizando a variável `NEXT_PUBLIC_API_URL`.
- Trata ausência da variável de ambiente para evitar URL indefinida.
- Mantém a indicação de API online ou offline com base na resposta `/health`.

## Testing
- `npm test` *(falhou: jest: not found)*
- `npm run cypress run` *(falhou: cypress: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839f31a2c28832d9a0fa7b07c57d5d0