### PR TITLE
Implement login with JWT and route protection

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,9 +1,8 @@
 import { Request, Response } from 'express';
 import bcrypt from 'bcryptjs';
-import jwt from 'jsonwebtoken';
 import prisma from '../prisma/client';
+import { generateToken } from '../middleware/auth';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
 export async function register(req: Request, res: Response) {
   // Extrai apenas os campos necessários do corpo da requisição. Isso evita que
@@ -64,7 +63,7 @@ export async function login(req: Request, res: Response) {
       return res.status(401).json({ error: 'Credenciais inválidas' });
     }
 
-    const token = jwt.sign({ userId: user.id, role: user.role }, JWT_SECRET);
+    const token = generateToken({ id: user.id, role: user.role });
     return res.json({ token });
   } catch (err) {
     return res.status(500).json({ error: 'Erro interno' });

--- a/backend/src/controllers/proposalController.ts
+++ b/backend/src/controllers/proposalController.ts
@@ -36,8 +36,8 @@ export async function createProposalForPost(req: AuthRequest, res: Response) {
     amount?: number;
     percentageRequested?: number;
   };
-  if (!req.user) return res.status(401).json({ error: 'Unauthorized' });
-  const investorId = req.user.userId;
+  if (!req.userId) return res.status(401).json({ error: 'Unauthorized' });
+  const investorId = req.userId;
   if (!postId || !amount) {
     return res.status(400).json({ error: 'Dados inválidos' });
   }

--- a/backend/src/middleware/adminOnly.ts
+++ b/backend/src/middleware/adminOnly.ts
@@ -1,21 +1,9 @@
-import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from './auth';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'secret';
-
-export function adminOnly(req: Request, res: Response, next: NextFunction) {
-  const auth = req.headers.authorization;
-  if (auth && auth.startsWith('Bearer ')) {
-    const token = auth.substring(7);
-    try {
-      const payload = jwt.verify(token, JWT_SECRET) as any;
-      if (payload.role !== 'admin') {
-        return res.status(403).json({ error: 'Forbidden' });
-      }
-      return next();
-    } catch {
-      return res.status(401).json({ error: 'Invalid token' });
-    }
+export function adminOnly(req: AuthRequest, res: Response, next: NextFunction) {
+  if (req.userType !== 'admin') {
+    return res.status(403).json({ error: 'Forbidden' });
   }
-  return res.status(401).json({ error: 'Unauthorized' });
+  next();
 }

--- a/backend/src/middleware/requireRole.ts
+++ b/backend/src/middleware/requireRole.ts
@@ -3,8 +3,8 @@ import { AuthRequest } from './auth';
 
 export function requireRole(roles: string[]) {
   return (req: AuthRequest, res: Response, next: NextFunction) => {
-    const user = req.user;
-    if (user && roles.includes(user.role)) {
+    const type = req.userType;
+    if (type && roles.includes(type)) {
       return next();
     }
     return res.status(403).json({ error: 'Forbidden' });

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -6,13 +6,13 @@ import {
   listNegotiations,
   listPosts,
 } from '../controllers/adminController';
-import { authMiddleware } from '../middleware/auth';
+import { verifyToken } from '../middleware/auth';
 import { adminOnly } from '../middleware/adminOnly';
 import prisma from '../prisma/client';
 
 const router = Router();
 
-router.use(authMiddleware);
+router.use(verifyToken);
 router.use(adminOnly);
 router.get('/dashboard', dashboard);
 router.get('/analytics', analytics);

--- a/backend/src/routes/boostRoutes.ts
+++ b/backend/src/routes/boostRoutes.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { createBoost, listBoosts } from '../controllers/boostController';
+import { verifyToken } from '../middleware/auth';
 
 const router = Router();
 
-router.post('/', createBoost);
+router.post('/', verifyToken, createBoost);
 router.get('/', listBoosts);
 
 export default router;

--- a/backend/src/routes/negotiationRoutes.ts
+++ b/backend/src/routes/negotiationRoutes.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
 import { updateNegotiation } from '../controllers/negotiationController';
+import { verifyToken } from '../middleware/auth';
 
 const router = Router();
 
-router.patch('/:id', updateNegotiation);
+router.patch('/:id', verifyToken, updateNegotiation);
 
 export default router;

--- a/backend/src/routes/postRoutes.ts
+++ b/backend/src/routes/postRoutes.ts
@@ -5,12 +5,13 @@ import {
   getPost,
   updatePostStatus,
 } from '../controllers/postController';
+import { verifyToken } from '../middleware/auth';
 
 const router = Router();
 
-router.post('/', createPost);
+router.post('/', verifyToken, createPost);
 router.get('/', listPosts);
 router.get('/:id', getPost);
-router.patch('/:id/status', updatePostStatus);
+router.patch('/:id/status', verifyToken, updatePostStatus);
 
 export default router;

--- a/backend/src/routes/proposalRoutes.ts
+++ b/backend/src/routes/proposalRoutes.ts
@@ -6,12 +6,12 @@ import {
   acceptProposal,
   rejectProposal,
 } from '../controllers/proposalController';
-import { authMiddleware } from '../middleware/auth';
+import { verifyToken } from '../middleware/auth';
 import { requireRole } from '../middleware/requireRole';
 
 const router = Router();
 
-router.use(authMiddleware);
+router.use(verifyToken);
 
 router.post('/propostas', requireRole(['investidor']), createProposalForPost);
 router.get('/posts/:id/propostas', requireRole(['empresa']), listPostProposals);

--- a/backend/src/routes/subscriptionRoutes.ts
+++ b/backend/src/routes/subscriptionRoutes.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { createSubscription, listSubscriptions } from '../controllers/subscriptionController';
+import { verifyToken } from '../middleware/auth';
 
 const router = Router();
 
-router.post('/', createSubscription);
+router.post('/', verifyToken, createSubscription);
 router.get('/', listSubscriptions);
 
 export default router;

--- a/frontend/src/components/withAuth.tsx
+++ b/frontend/src/components/withAuth.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { useAuth } from '../contexts/AuthContext';
+import { getToken, parseToken } from '../utils/auth';
 
 export function withAuth<P extends object>(
   WrappedComponent: React.ComponentType<P>,
@@ -8,18 +8,20 @@ export function withAuth<P extends object>(
 ) {
   const ComponentWithAuth: React.FC<P> = (props) => {
     const router = useRouter();
-    const { user } = useAuth();
 
     useEffect(() => {
-      if (!user) {
+      const token = getToken();
+      if (!token) {
         router.push('/login');
         return;
       }
 
-      if (!allowedRoles.includes(user.role)) {
-        router.push('/');
+      const payload = parseToken(token);
+      const role = payload?.type || payload?.role;
+      if (!role || !allowedRoles.includes(role.toLowerCase())) {
+        router.push('/login');
       }
-    }, [user, router]);
+    }, [router]);
 
     return <WrappedComponent {...props} />;
   };

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -16,9 +16,11 @@ export default function Login() {
       const token = res.data.token;
       setToken(token);
       const payload = parseToken(token);
-      if (payload?.role) {
-        setRole(payload.role);
-        router.push(getDashboardRoute(payload.role));
+      const role = payload?.type || payload?.role;
+      if (role) {
+        const normalized = role.toLowerCase();
+        setRole(normalized);
+        router.push(getDashboardRoute(normalized));
       } else {
         router.push('/');
       }


### PR DESCRIPTION
## Summary
- issue JWT on login using helper
- verify token middleware injects userId/userType
- apply token verification to private routes
- use new roles on login page
- guard dashboard pages with token

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci --prefix backend` *(fails: network access)*


------
https://chatgpt.com/codex/tasks/task_e_683cbe752db8832da545a25d3cec71ee