### PR TITLE
feat: create initial dashboards

### DIFF
--- a/frontend/src/pages/dashboard/admin.tsx
+++ b/frontend/src/pages/dashboard/admin.tsx
@@ -1,0 +1,25 @@
+import { withAuth } from '../../components/withAuth';
+
+function AdminDashboard() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold mb-6">Painel do Administrador</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="p-4 bg-white rounded shadow">
+          <p className="text-gray-600">Usuários cadastrados</p>
+          <p className="text-2xl font-bold">0</p>
+        </div>
+        <div className="p-4 bg-white rounded shadow">
+          <p className="text-gray-600">Projetos pendentes</p>
+          <p className="text-2xl font-bold">0</p>
+        </div>
+        <div className="p-4 bg-white rounded shadow">
+          <p className="text-gray-600">Total investido</p>
+          <p className="text-2xl font-bold">R$ 0,00</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default withAuth(AdminDashboard, ['admin']);

--- a/frontend/src/pages/dashboard/empresa.tsx
+++ b/frontend/src/pages/dashboard/empresa.tsx
@@ -1,0 +1,23 @@
+import { withAuth } from '../../components/withAuth';
+import { getToken, parseToken } from '../../utils/auth';
+
+function EmpresaDashboard() {
+  const token = getToken();
+  const payload = token ? parseToken(token) : null;
+  const name = payload?.name || 'Empresa';
+
+  return (
+    <div>
+      <div className="p-4 bg-white rounded shadow mb-4">
+        <h1 className="text-xl font-semibold">Bem-vindo, {name}</h1>
+      </div>
+      <button className="mb-6 bg-blue-600 text-white px-4 py-2 rounded">
+        Cadastrar novo projeto
+      </button>
+      <h2 className="text-lg font-semibold mb-2">Meus projetos</h2>
+      <p>Nenhum projeto cadastrado.</p>
+    </div>
+  );
+}
+
+export default withAuth(EmpresaDashboard, ['empresa']);

--- a/frontend/src/pages/dashboard/investidor.tsx
+++ b/frontend/src/pages/dashboard/investidor.tsx
@@ -1,0 +1,28 @@
+import { withAuth } from '../../components/withAuth';
+
+const projects = [
+  { id: 1, name: 'Projeto A', target: 50000 },
+  { id: 2, name: 'Projeto B', target: 75000 },
+  { id: 3, name: 'Projeto C', target: 100000 },
+];
+
+function InvestidorDashboard() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold mb-6">Bem-vindo ao ScaleX Invest</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {projects.map((project) => (
+          <div key={project.id} className="p-4 bg-white rounded shadow">
+            <h2 className="font-semibold text-lg mb-2">{project.name}</h2>
+            <p className="mb-4">Meta: R$ {project.target.toLocaleString()}</p>
+            <button className="bg-blue-600 text-white px-3 py-1 rounded">
+              Ver mais
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default withAuth(InvestidorDashboard, ['investidor']);

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -47,10 +47,10 @@ export function parseToken(token: string): any | null {
 export function getDashboardRoute(role: string | null) {
   switch (role) {
     case 'empresa':
-      return '/empresa/dashboard';
+      return '/dashboard/empresa';
     case 'admin':
-      return '/admin/painel';
+      return '/dashboard/admin';
     default:
-      return '/investidor/dashboard';
+      return '/dashboard/investidor';
   }
 }


### PR DESCRIPTION
## Summary
- add minimal dashboards for admin, empresa and investidor
- redirect post-login users to the new dashboard routes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run cypress` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cc4bf8b78832d9e886efd33a22ffe