### PR TITLE
Fix project creation and session persistence

### DIFF
--- a/backend/src/controllers/investmentProjectController.ts
+++ b/backend/src/controllers/investmentProjectController.ts
@@ -3,7 +3,14 @@ import prisma from '../prisma/client';
 import { AuthRequest } from '../middleware/auth';
 
 export async function createProject(req: AuthRequest, res: Response) {
-  const { title, description, targetValue, quotaCount, category, media } = req.body as {
+  const {
+    title,
+    description,
+    targetValue,
+    quotaCount,
+    category,
+    media,
+  } = req.body as {
     title?: string;
     description?: string;
     targetValue?: number;
@@ -16,8 +23,14 @@ export async function createProject(req: AuthRequest, res: Response) {
     return res.status(403).json({ error: 'Acesso negado' });
   }
 
-  if (!title || !description || !targetValue || !quotaCount || !category) {
-    return res.status(400).json({ error: 'Dados inválidos' });
+  if (
+    !title ||
+    !description ||
+    targetValue === undefined ||
+    quotaCount === undefined ||
+    !category
+  ) {
+    return res.status(422).json({ error: 'Dados inválidos' });
   }
 
   try {
@@ -28,13 +41,14 @@ export async function createProject(req: AuthRequest, res: Response) {
         targetValue: Number(targetValue),
         quotaCount: Number(quotaCount),
         category,
-        media,
+        media: media || undefined,
         userId: req.userId!,
       },
     });
     return res.status(201).json(project);
-  } catch {
-    return res.status(400).json({ error: 'Erro ao criar projeto' });
+  } catch (err) {
+    console.error('Erro ao criar projeto:', err);
+    return res.status(500).json({ error: 'Erro ao criar projeto' });
   }
 }
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -14,10 +14,12 @@ export function verifyToken(
   next: NextFunction
 ) {
   const auth = req.headers.authorization;
+  console.log('verifyToken header', auth);
   if (auth && auth.startsWith('Bearer ')) {
     const token = auth.substring(7);
     try {
       const payload = jwt.verify(token, JWT_SECRET) as any;
+      console.log('token payload', payload);
       req.userId = payload.userId;
       req.userType = payload.type || payload.role;
       return next();

--- a/frontend/src/components/withAuth.tsx
+++ b/frontend/src/components/withAuth.tsx
@@ -9,10 +9,12 @@ export function withAuth<P extends object>(
 ) {
   const ComponentWithAuth: React.FC<P> = (props) => {
     const router = useRouter();
-    const { setUser } = useAuth();
+    const { setUser, loading } = useAuth();
 
     useEffect(() => {
+      if (loading) return;
       const token = getToken();
+      console.log('withAuth token', token);
       if (!token) {
         router.push('/login');
         return;
@@ -20,6 +22,7 @@ export function withAuth<P extends object>(
 
       const payload = parseToken(token);
       const role = payload?.type || payload?.role;
+      console.log('withAuth payload', payload);
       if (!role || !allowedRoles.includes(role.toLowerCase())) {
         router.push('/login');
         return;
@@ -30,7 +33,7 @@ export function withAuth<P extends object>(
         name: payload?.name,
         userId: payload?.userId,
       });
-    }, [router, setUser]);
+    }, [router, setUser, loading]);
 
     return <WrappedComponent {...props} />;
   };

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -10,18 +10,22 @@ export type User = {
 interface AuthContextType {
   user: User | null;
   setUser: (u: User | null) => void;
+  loading: boolean;
 }
 
 const AuthContext = createContext<AuthContextType>({
   user: null,
   setUser: () => {},
+  loading: true,
 });
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const token = getToken();
+    console.log('AuthProvider init token', token);
     if (token) {
       const payload = parseToken(token);
       if (payload) {
@@ -32,10 +36,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         });
       }
     }
+    setLoading(false);
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, setUser }}>
+    <AuthContext.Provider value={{ user, setUser, loading }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -7,6 +7,7 @@ const api = axios.create({
 
 api.interceptors.request.use((config) => {
   const token = getToken();
+  console.log('api token', token);
   if (token && config.headers) {
     config.headers.Authorization = `Bearer ${token}`;
   }


### PR DESCRIPTION
## Summary
- allow optional media when creating projects
- log tokens during auth for debugging
- persist auth session across reloads
- wait for context to load before redirecting

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm run cypress run --prefix frontend` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cd6d81568832d968d708aba1b8eca